### PR TITLE
Foreman needs an env file to set environment variables

### DIFF
--- a/lib/recap/tasks/foreman.rb
+++ b/lib/recap/tasks/foreman.rb
@@ -19,7 +19,7 @@ module Recap::Tasks::Foreman
     set(:foreman_export_location, "/etc/init")
 
     # The standard foreman export.
-    set(:foreman_export_command) { "./bin/foreman export #{foreman_export_format} #{foreman_tmp_location} --procfile #{procfile} --app #{application} --user #{application_user} --log #{deploy_to}/log" }
+    set(:foreman_export_command) { "./bin/foreman export #{foreman_export_format} #{foreman_tmp_location} --procfile #{procfile} --app #{application} --user #{application_user} --log #{deploy_to}/log --env #{environment_file}" }
 
     namespace :export do
       # After each deployment, the startup scripts are exported if the `Procfile` has changed.


### PR DESCRIPTION
As of ddollar/foreman@c039f379ff1b6eb87673aa73a3548ba20d1722e4,
Foreman won't run a shell to run the command under upstart, but
uses a `.env` file and inserts the environment variables directly into
the upstart scripts.
